### PR TITLE
Add new `Node#degree` class property accessor method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -22,6 +22,10 @@ class Node {
     return children;
   }
 
+  get degree() {
+    return this.children.length;
+  }
+
   get left() {
     return this._left;
   }


### PR DESCRIPTION
## Description

The PR introduces the following unary class method: 

- `Node#degree`

Return the degree of the node, which can be: `0`, `1` or `2`.