### PR TITLE
Add new `Node#toPair()` class method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -69,6 +69,10 @@ class Node {
   isLeaf() {
     return !this.left && !this.right;
   }
+
+  toPair() {
+    return [this.key, this.value];
+  }
 }
 
 module.exports = Node;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#toPair()`

The method returns an ordered-pair/2-tuple, where the first element is a number corresponding to the `key` of the node, and the last one is a value, that can be of any type, corresponding to the `value` stored in the node.
