### PR TITLE
Add new `Node#isRightPartial()` predicate class method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -78,6 +78,10 @@ class Node {
     return this.degree === 1;
   }
 
+  isRightPartial() {
+    return !this.left && this.right !== null;
+  }
+
   toPair() {
     return [this.key, this.value];
   }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary predicate method: 

- `Node#isRightPartial()`

The methods return `true` if the node instance is a right-partial node (has only one non-null right child), or `false` if it is a leaf, a full or a left partial node.
