### PR TITLE
Add new `Tree#includes(key)` predicate class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -14,6 +14,20 @@ class Tree {
     return this;
   }
 
+  includes(key) {
+    let {root: current} = this;
+
+    while (current) {
+      if (key === current.key) {
+        return true;
+      }
+
+      current = key < current.key ? current.left : current.right;
+    }
+
+    return false;
+  }
+
   isEmpty() {
     return !this.root;
   }

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -30,6 +30,7 @@ declare namespace tree {
   export interface Instance<T> {
     readonly root: Node<T> | null;
     clear(): this;
+    includes(key: number): boolean;
     isEmpty(): boolean;
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Tree#includes(key)`

The methods can be used to determine whether the tree includes a node with a certain key, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
