### PR TITLE
Add new `Node#balanceFactor` class property accessor method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -9,6 +9,10 @@ class Node {
     this._value = value;
   }
 
+  get balanceFactor() {
+    return this.right.height - this.left.height;
+  }
+
   get children() {
     const children = [];
 

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -7,6 +7,7 @@ declare namespace node {
     value: T;
     left: Instance<T> | null;
     right: Instance<T> | null;
+    readonly balanceFactor: number;
     readonly key: number;
     readonly children: Instance<T>[];
     readonly degree: 0 | 1 | 2;


### PR DESCRIPTION
## Description

The PR introduces the following new accessor method: 

- `Node#balanceFactor`

Returns a number corresponding to the balance factor of a node which is defined to be the height difference of its two child sub-trees. 

Also, the corresponding TypeScript ambient declarations are included in the PR.
