### PR TITLE
Add new `Node#rightChildHeight()` class method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -95,6 +95,14 @@ class Node {
     return !this.left && this.right !== null;
   }
 
+  rightChildHeight() {
+    if (this.right) {
+      return this.right.height;
+    }
+
+    return -1;
+  }
+
   toPair() {
     return [this.key, this.value];
   }

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -17,6 +17,7 @@ declare namespace node {
     isLeftPartial(): boolean;
     isPartial(): boolean;
     isRightPartial(): boolean;
+    rightChildHeight(): number;
     toPair(): [number, T];
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#rightChildHeight()`

The method returns the number of edges from the right child node instance to the deepest leaf node. If the right child node does not exist, then `-1` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
