### PR TITLE
Add new `Node#leftChildIndex()` class method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -95,6 +95,14 @@ class Node {
     return !this.left && this.right !== null;
   }
 
+  leftChildHeight() {
+    if (this.left) {
+      return this.left.height;
+    }
+
+    return -1;
+  }
+
   rightChildHeight() {
     if (this.right) {
       return this.right.height;

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -17,6 +17,7 @@ declare namespace node {
     isLeftPartial(): boolean;
     isPartial(): boolean;
     isRightPartial(): boolean;
+    leftChildHeight(): number;
     rightChildHeight(): number;
     toPair(): [number, T];
   }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#leftChildHeight()`

The method returns the number of edges from the left child node instance to the deepest leaf node. If the left child node does not exist, then `-1` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
