### PR TITLE
Add new `Node#isLeftHeavy()` predicate class method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -83,6 +83,10 @@ class Node {
     return !this.left && !this.right;
   }
 
+  isLeftHeavy() {
+    return this.balanceFactor < 0;
+  }
+
   isLeftPartial() {
     return this.left !== null && !this.right;
   }

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -14,6 +14,7 @@ declare namespace node {
     isFull(): boolean;
     isInternal(): boolean;
     isLeaf(): boolean;
+    isLeftHeavy(): boolean;
     isLeftPartial(): boolean;
     isPartial(): boolean;
     isRightPartial(): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Node#isLeftHeavy()`

Determines whether the node is `left-heavy` (has a negative `balance-factor`) and returns `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
