### PR TITLE
Add new `Node#isRightHeavy()` predicate class method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -95,6 +95,10 @@ class Node {
     return this.degree === 1;
   }
 
+  isRightHeavy() {
+    return this.balanceFactor > 0;
+  }
+
   isRightPartial() {
     return !this.left && this.right !== null;
   }

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -17,6 +17,7 @@ declare namespace node {
     isLeftHeavy(): boolean;
     isLeftPartial(): boolean;
     isPartial(): boolean;
+    isRightHeavy(): boolean;
     isRightPartial(): boolean;
     leftChildHeight(): number;
     rightChildHeight(): number;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Node#isRightHeavy()`

Determines whether the node is `right-heavy` (has a positive `balance-factor`) and returns `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
