### PR TITLE
Add new `Tree#search(key)` class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -83,6 +83,20 @@ class Tree {
   minValue() {
     return this._prop(this.min(), 'value');
   }
+
+  search(key) {
+    let {root: current} = this;
+
+    while (current) {
+      if (key === current.key) {
+        return current;
+      }
+
+      current = key < current.key ? current.left : current.right;
+    }
+
+    return current;
+  }
 }
 
 module.exports = Tree;

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -43,6 +43,7 @@ declare namespace tree {
     min(): Node<T> | null;
     minKey(): number | null;
     minValue(): T | null;
+    search(key: number): Node<T> | null;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#search(key)`

The method returns the corresponding node to the `key`, if and only if the node is present inside the tree. On the contrary, if the node is absent, the method returns `null`.

Also, the corresponding TypeScript ambient declarations are included in the PR.
