### PR TITLE
Add new `Tree#inOrder(fn)` class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -48,6 +48,24 @@ class Tree {
     return false;
   }
 
+  inOrder(fn) {
+    const stack = [];
+    let {root: current} = this;
+
+    while (current || stack.length > 0) {
+      if (current) {
+        stack.push(current);
+        current = current.left;
+      } else {
+        current = stack.pop();
+        fn(current);
+        current = current.right;
+      }
+    }
+
+    return this;
+  }
+
   isEmpty() {
     return !this.root;
   }

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -38,6 +38,7 @@ declare namespace tree {
     readonly root: Node<T> | null;
     clear(): this;
     includes(key: number): boolean;
+    inOrder(fn: UnaryCallback<Node<T>>): this;
     isEmpty(): boolean;
     max(): Node<T> | null;
     maxKey(): number | null;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#inOrder(fn)`

The method traverses the AVL binary search tree in-order and applies the `fn` function to each traversed node. At the end of the traversal, the method returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
