### PR TITLE
Add new `Tree#toPairs()` class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -121,6 +121,12 @@ class Tree {
     this.inOrder(node => array.push(node));
     return array;
   }
+
+  toPairs() {
+    const array = [];
+    this.inOrder(node => array.push(node.toPair()));
+    return array;
+  }
 }
 
 module.exports = Tree;

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -48,6 +48,7 @@ declare namespace tree {
     minValue(): T | null;
     search(key: number): Node<T> | null;
     toArray(): Node<T>[];
+    toPairs(): [number, T][];
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Tree#toPairs()`

Applies in-order traversal to the tree and for each traversed node stores in an array of length `n`, where `n` the size of the tree, an ordered-pair/2-tuple, where the first element is a `number` corresponding to the `key` of the traversed node, and the last one is a value of type `any`, corresponding to the `value` stored in the traversed node.
The array is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.
