### PR TITLE
Add new `Tree#outOrder(fn)` class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -102,6 +102,24 @@ class Tree {
     return this._prop(this.min(), 'value');
   }
 
+  outOrder(fn) {
+    const stack = [];
+    let {root: current} = this;
+
+    while (current || stack.length > 0) {
+      if (current) {
+        stack.push(current);
+        current = current.right;
+      } else {
+        current = stack.pop();
+        fn(current);
+        current = current.left;
+      }
+    }
+
+    return this;
+  }
+
   search(key) {
     let {root: current} = this;
 

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -46,6 +46,7 @@ declare namespace tree {
     min(): Node<T> | null;
     minKey(): number | null;
     minValue(): T | null;
+    outOrder(fn: UnaryCallback<Node<T>>): this;
     search(key: number): Node<T> | null;
     size(): number;
     toArray(): Node<T>[];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#outOrder(fn)`

The method applies `out order` traversal to the AVL binary search tree and executes the provided `fn` function once for each traversed node. At the end of the traversal, the method returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
