### PR TITLE
Add new `Tree#preOrder(fn)` class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -120,6 +120,29 @@ class Tree {
     return this;
   }
 
+  preOrder(fn) {
+    let {_root: current} = this;
+
+    if (current) {
+      const stack = [current];
+
+      while (stack.length > 0) {
+        current = stack.pop();
+        fn(current);
+
+        if (current.right) {
+          stack.push(current.right);
+        }
+
+        if (current.left) {
+          stack.push(current.left);
+        }
+      }
+    }
+
+    return this;
+  }
+
   search(key) {
     let {root: current} = this;
 

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -47,6 +47,7 @@ declare namespace tree {
     minKey(): number | null;
     minValue(): T | null;
     outOrder(fn: UnaryCallback<Node<T>>): this;
+    preOrder(fn: UnaryCallback<Node<T>>): this;
     search(key: number): Node<T> | null;
     size(): number;
     toArray(): Node<T>[];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#preOrder(fn)`

The method applies `pre order` traversal to the AVL binary search tree and executes the provided `fn` function once for each traversed node. At the end of the traversal, the method returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
