### PR TITLE
Add new `Tree#postOrder(fn)` class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -120,6 +120,30 @@ class Tree {
     return this;
   }
 
+  postOrder(fn) {
+    let last = null;
+    const stack = [];
+    let {root: current} = this;
+
+    while (current || stack.length > 0) {
+      if (current) {
+        stack.push(current);
+        current = current.left;
+      } else {
+        const recent = stack[stack.length - 1];
+
+        if (recent.right && recent.right !== last) {
+          current = recent.right;
+        } else {
+          fn(recent);
+          last = stack.pop();
+        }
+      }
+    }
+
+    return this;
+  }
+
   preOrder(fn) {
     let {root: current} = this;
 

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -47,6 +47,7 @@ declare namespace tree {
     minKey(): number | null;
     minValue(): T | null;
     outOrder(fn: UnaryCallback<Node<T>>): this;
+    postOrder(fn: UnaryCallback<Node<T>>): this;
     preOrder(fn: UnaryCallback<Node<T>>): this;
     search(key: number): Node<T> | null;
     size(): number;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#postOrder(fn)`

The method applies `post order` traversal to the AVL binary search tree and executes the provided `fn` function once for each traversed node. At the end of the traversal, the method returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
