### PR TITLE
Add new `Tree#levelOrder(fn)` class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -70,6 +70,23 @@ class Tree {
     return !this.root;
   }
 
+  levelOrder(fn) {
+    let {root: current} = this;
+
+    if (current) {
+      const queue = [];
+      queue.push(current);
+
+      while (queue.length > 0) {
+        current = queue.shift();
+        fn(current);
+        queue.push(...current.children);
+      }
+    }
+
+    return this;
+  }
+
   max() {
     let {root: max} = this;
 

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -40,6 +40,7 @@ declare namespace tree {
     includes(key: number): boolean;
     inOrder(fn: UnaryCallback<Node<T>>): this;
     isEmpty(): boolean;
+    levelOrder(fn: UnaryCallback<Node<T>>): this;
     max(): Node<T> | null;
     maxKey(): number | null;
     maxValue(): T | null;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#levelOrder(fn)`

The method applies `level order` traversal to the AVL binary search tree and executes the provided `fn` function once for each traversed node. At the end of the traversal, the method returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
