### PR TITLE
Add new `Node#maxChildHeight()` class method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -111,6 +111,10 @@ class Node {
     return -1;
   }
 
+  maxChildHeight() {
+    return Math.max(this.leftChildHeight(), this.rightChildHeight());
+  }
+
   rightChildHeight() {
     if (this.right) {
       return this.right.height;

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -20,6 +20,7 @@ declare namespace node {
     isRightHeavy(): boolean;
     isRightPartial(): boolean;
     leftChildHeight(): number;
+    maxChildHeight(): number;
     rightChildHeight(): number;
     toPair(): [number, T];
   }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#maxChildHeight()`

The method returns the maximum height between the child nodes of the parent `Node` instance.

Also, the corresponding TypeScript ambient declarations are included in the PR.
