### PR TITLE
Add new `Node#isBalanced()` predicate class method (#2)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -93,6 +93,10 @@ class Node {
     this._value = value;
   }
 
+  isBalanced() {
+    return this.balanceFactor === 0;
+  }
+
   isFull() {
     return this.left !== null && this.right !== null;
   }

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -11,6 +11,7 @@ declare namespace node {
     readonly key: number;
     readonly children: Instance<T>[];
     readonly degree: 0 | 1 | 2;
+    isBalanced(): boolean;
     isFull(): boolean;
     isInternal(): boolean;
     isLeaf(): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Node#isBalanced()`

Determines whether the node is `balanced`, has a `balance-factor` equal to zero - 0, and returns `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
