### PR TITLE
Add new `Tree#remove(key)` class method. Fixes #2 & fixes #3

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -105,6 +105,33 @@ class Tree {
     return null;
   }
 
+  _remove(key, node) {
+    if (key < node.key) {
+      node.left = this._remove(key, node.left);
+    } else if (key > node.key) {
+      node.right = this._remove(key, node.right);
+    } else if (node.isLeaf()) {
+      node = null;
+    } else if (node.isRightPartial()) {
+      node = node.right;
+    } else if (node.isLeftPartial()) {
+      node = node.left;
+    } else {
+      const successor = this._min(node.right);
+      node._key = successor.key;
+      node.value = successor.value;
+      node.right = this._remove(successor.key, node.right);
+    }
+
+    if (!node) {
+      return node;
+    }
+
+    node._height = node.maxChildHeight() + 1;
+
+    return this._balanceSubtree(node);
+  }
+
   clear() {
     this._root = null;
     return this;
@@ -384,6 +411,16 @@ class Tree {
           stack.push(current.left);
         }
       }
+    }
+
+    return this;
+  }
+
+  remove(key) {
+    const {root} = this;
+
+    if (root) {
+      this._root = this._remove(key, root);
     }
 
     return this;

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -60,6 +60,7 @@ declare namespace tree {
     outOrder(fn: UnaryCallback<Node<T>>): this;
     postOrder(fn: UnaryCallback<Node<T>>): this;
     preOrder(fn: UnaryCallback<Node<T>>): this;
+    remove(key: number): this;
     search(key: number): Node<T> | null;
     size(): number;
     toArray(): Node<T>[];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#remove(key)`

The method mutates the AVL tree by removing the node corresponding to the given key and returns the AVL tree itself, while also maintaining its balanced property.

Also, the corresponding TypeScript ambient declarations are included in the PR.
