### PR TITLE
Add new `Tree#height()` class method (#2)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -149,6 +149,16 @@ class Tree {
     return nodes;
   }
 
+  height() {
+    const {root} = this;
+
+    if (root) {
+      return root.height;
+    }
+
+    return -1;
+  }
+
   includes(key) {
     let {root: current} = this;
 

--- a/types/avlbinstree.d.ts
+++ b/types/avlbinstree.d.ts
@@ -41,6 +41,7 @@ declare namespace tree {
     readonly root: Node<T> | null;
     clear(): this;
     fullNodes(): Node<T>[];
+    height(): number;
     includes(key: number): boolean;
     inOrder(fn: UnaryCallback<Node<T>>): this;
     insert(key: number, value: T): this;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Tree#height()`

The method returns the maximum distance of any node from the root, also knows as the height of the AVL binary search tree. If the tree is empty `-1` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
